### PR TITLE
`binary_mask_to_polygon` bugfix

### DIFF
--- a/pycococreatortools/pycococreatortools.py
+++ b/pycococreatortools/pycococreatortools.py
@@ -45,8 +45,8 @@ def binary_mask_to_polygon(binary_mask, tolerance=0):
     # pad mask to close contours of shapes which start and end at an edge
     padded_binary_mask = np.pad(binary_mask, pad_width=1, mode='constant', constant_values=0)
     contours = measure.find_contours(padded_binary_mask, 0.5)
-    contours = np.subtract(contours, 1)
     for contour in contours:
+        contour = np.subtract(contour, 1)
         contour = close_contour(contour)
         contour = measure.approximate_polygon(contour, tolerance)
         if len(contour) < 3:


### PR DESCRIPTION
Fix bug with the subtract of a list of contours of different shapes.

The following error happens with Python 3.8:
```bash
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```